### PR TITLE
Fix tip image URLs

### DIFF
--- a/layouts/partials/home_improvement_card.html
+++ b/layouts/partials/home_improvement_card.html
@@ -3,43 +3,43 @@
 <script type="text/javascript">
   cards = [
     {
-      image: "https://www.nfpa.org/-/media/Images/Public-Education/By-topic/wildland/PrepDay/2021/2021PrepDay2WaysOut300.ashx?h=157&w=300&hash=0C9E976212E3BE5A329ABE481D53A5C3",
-      url: "https://www.nfpa.org/Public-Education/By-topic/Wildfire/Wildfire-safety-tips"
+      image: "https://www.nfpa.org/-/media/Import/Images/Public-Education-2/By-topic/wildland/PrepDay/2021/2021PrepDay2WaysOut300.jpg",
+      url: "https://www.nfpa.org/education-and-research/wildfire"
     },
     {
-      image: "https://www.nfpa.org/-/media/Images/Public-Education/By-topic/wildland/PrepDay/2021/2021PrepDayEmbers300.ashx?h=157&w=300&hash=93506C80EBE75C87A8CD237D2D44572A",
-      url: "https://www.nfpa.org/Public-Education/By-topic/Wildfire/Wildfire-safety-tips"
+      image: "https://www.nfpa.org/-/media/Import/Images/Public-Education-2/By-topic/wildland/PrepDay/2021/2021PrepDayEmbers300.jpg",
+      url: "https://www.nfpa.org/education-and-research/wildfire"
     },
     {
-      image: "https://www.nfpa.org/-/media/Images/Public-Education/By-topic/wildland/PrepDay/2021/2021PrepDayWoodPiles300.ashx?h=157&w=300&hash=58C112970559E875A2F81A222B601643",
+      image: "https://www.nfpa.org/-/media/Import/Images/Public-Education-2/By-topic/wildland/PrepDay/2021/2021PrepDayWoodPiles300.jpg",
       url: "https://www.nfpa.org/Public-Education/Fire-causes-and-risks/Wildfire/Preparing-homes-for-wildfire"
     },
     {
-      image: "https://www.nfpa.org/-/media/Images/Public-Education/By-topic/wildland/PrepDay/2021/2021PrepDayLandscaping300.ashx?h=157&w=300&hash=1D3C7D170482E17B2D11A635DE4EF73F",
+      image: "https://www.nfpa.org/-/media/Import/Images/Public-Education-2/By-topic/wildland/PrepDay/2021/2021PrepDayLandscaping300.jpg",
       url: "https://www.nfpa.org/Public-Education/Fire-causes-and-risks/Wildfire/Preparing-homes-for-wildfire"
     },
     {
-      image: "https://www.nfpa.org/-/media/Images/Public-Education/By-topic/wildland/PrepDay/2021/2021PrepDayScreenVents300.ashx?h=157&w=300&hash=4354CD9635AABC9A0FE11BFD2ECE00A1",
-      url: "https://www.nfpa.org/Public-Education/Fire-causes-and-risks/Wildfire/Firewise-USA/Firewise-USA-Resources/Research-Fact-Sheet-Series"
+      image: "https://www.nfpa.org/-/media/Import/Images/Public-Education-2/By-topic/wildland/PrepDay/2021/2021PrepDayScreenVents300.jpg",
+      url: "https://www.nfpa.org/education-and-research/wildfire"
     },
     {
-      image: "https://www.nfpa.org/-/media/Images/Public-Education/By-topic/wildland/PrepDay/2021/2021PrepDayWildfirethreatens300.ashx?h=157&w=300&hash=68F756C8B51214B46A80E240F313DF68",
+      image: "https://www.nfpa.org/-/media/Import/Images/Public-Education-2/By-topic/wildland/PrepDay/2021/2021PrepDayWildfirethreatens300.jpg",
       url: "https://www.nfpa.org/Public-Education/Fire-causes-and-risks/Wildfire/Preparing-homes-for-wildfire"
     },
     {
-      image: "https://www.nfpa.org/-/media/Images/Public-Education/By-topic/wildland/PrepDay/2021/2021PrepDayLawnDebris2300.ashx?h=157&w=300&hash=439238AD561165368EB08827D70C0813",
+      image: "https://www.nfpa.org/-/media/Import/Images/Public-Education-2/By-topic/wildland/PrepDay/2021/2021PrepDayLawnDebris2300.jpg",
       url: "https://www.nfpa.org/Public-Education/Fire-causes-and-risks/Wildfire/Preparing-homes-for-wildfire"
     },
     {
-      image: "https://www.nfpa.org/-/media/Images/Public-Education/By-topic/wildland/PrepDay/2021/2021PrepDayLawnDebris300.ashx?h=157&w=300&hash=5967959576231B3FB862A8845C6A8823",
+      image: "https://www.nfpa.org/-/media/Import/Images/Public-Education-2/By-topic/wildland/PrepDay/2021/2021PrepDayLawnDebris300.jpg",
       url: "https://www.nfpa.org/Public-Education/Fire-causes-and-risks/Wildfire/Preparing-homes-for-wildfire"
     },
     {
-      image: "https://www.nfpa.org/-/media/Images/Public-Education/By-topic/wildland/PrepDay/2021/2021PrepDayPets300.ashx?h=157&w=300&hash=75F5656DE4EC1D43FB79073C09557300",
+      image: "https://www.nfpa.org/-/media/Import/Images/Public-Education-2/By-topic/wildland/PrepDay/2021/2021PrepDayPets300.jpg",
       url: "https://www.nfpa.org/Public-Education/Fire-causes-and-risks/Wildfire/TakeAction/Household-pets"
     },
     {
-      image: "https://www.nfpa.org/-/media/Images/Public-Education/By-topic/wildland/PrepDay/2021/2021PrepDayHorses300.ashx?h=157&w=300&hash=27BE8DE9541D57F0359639F84A19FC5E",
+      image: "https://www.nfpa.org/-/media/Import/Images/Public-Education-2/By-topic/wildland/PrepDay/2021/2021PrepDayHorses300.jpg",
       url: "https://www.nfpa.org/Public-Education/Fire-causes-and-risks/Wildfire/TakeAction/Horses"
     }
   ]


### PR DESCRIPTION
Looks like nfpa.org changed the URLs, resulting in

![image](https://github.com/stefanv/prosser-firewise/assets/41166/885c3682-d315-4123-b047-df6ffc7c3a7e)
