### PR TITLE
Indicate certificate validity

### DIFF
--- a/layouts/partials/documents.html
+++ b/layouts/partials/documents.html
@@ -3,12 +3,12 @@
 <ul>
     <li>
         🌟 <a class="" href="/files/Prosser_Lakeview_Woods_2023_Certificate.pdf">
-            2023 National Firewise USA Program Certificate (pdf)
+            2023 National Firewise USA Program Certificate, valid through 2024 (pdf)
         </a>
     </li>
     <li>
         🌟 <a class="" href="/files/Prosser_Lakeview_Woods_2022_Certificate.pdf">
-            2022 National Firewise USA Program Certificate (pdf)
+            2022 National Firewise USA Program Certificate, valid through 2023 (pdf)
         </a>
     </li>
     <li>


### PR DESCRIPTION
Not sure this is a best way, but I think it's better than renaming the certificates since their year is printed in BIG ORANGE BOLD at the top!