### PR TITLE
Add 2026 events and improve mobile header layout

### DIFF
--- a/assets/prosser.css
+++ b/assets/prosser.css
@@ -2,21 +2,90 @@ html {
   font-size: 105%;
 }
 
+.site-header {
+  padding-left: 0;
+  padding-right: 0;
+}
+
 .site-nav {
-  padding-bottom: 2rem;
+  box-sizing: border-box;
+  padding-bottom: 0.5rem;
   padding-left: 1rem;
   padding-right: 1rem;
   /*border-bottom: solid 1.5px gray;*/
   box-shadow: 0px 15px 15px -15px lightgray;
 }
 
+.site-brand,
+.site-links {
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
 .subtitle {
   font-style: italic;
+}
+
+.site-wordmark {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  white-space: nowrap;
+}
+
+.site-wordmark .site-logo {
+  height: 1em;
+  width: auto;
+  font-size: 2rem;
+}
+
+.site-wordmark .site-title {
+  font-size: 2rem;
+}
+
+@media screen and (min-width: 60em) {
+  .site-wordmark .site-logo,
+  .site-wordmark .site-title {
+    font-size: 3rem;
+  }
+}
+
+.site-brand {
+  text-align: left;
+}
+
+@media screen and (max-width: 60em) {
+  .subtitle {
+    margin-top: 0.5rem;
+    text-align: left;
+  }
+  .site-links {
+    margin-top: 1rem;
+    width: 100%;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.25rem 0.5rem;
+  }
+  .site-links a {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media screen and (max-width: 460px) {
+  .site-links a {
+    flex: 1 0 30%;
+    text-align: left;
+  }
 }
 
 .page-image {
   padding: 0.75rem;
   box-shadow: 0 3px 10px gray;
+  max-width: 100%;
+  height: auto;
 }
 
 .site-links {
@@ -119,4 +188,16 @@ a.clickable-banner-link {
   padding: 1rem;
   background: #EAEBDD;
   border-radius: 1rem;
+}
+
+.community-events {
+  padding: 1rem 1.25rem;
+  background: #DAE8D2;
+  border-radius: 1rem;
+}
+
+@media screen and (min-width: 60em) {
+  .home-columns {
+    gap: 3rem;
+  }
 }

--- a/assets/prosser.css
+++ b/assets/prosser.css
@@ -22,6 +22,17 @@ html {
   padding-right: 1rem;
 }
 
+.site-social {
+  display: inline-flex;
+  white-space: nowrap;
+  gap: 1rem;
+}
+
+.site-social a {
+  padding-left: 0;
+  padding-right: 0;
+}
+
 .subtitle {
   font-style: italic;
 }

--- a/config.yaml
+++ b/config.yaml
@@ -33,7 +33,7 @@ permalinks:
   events: '/events/:year/:title'
 
 params:
-  subtitle: Serving the neighborhoods of Prosser Lakeview and Prosser Woods Estates
+  subtitle: Serving Prosser Lakeview Estates and Woods neighborhoods in Truckee, CA
   orgName: Prosser Firewise
   favicon: /img/favicon.ico?v=0
   logo: /img/fire-alert.svg

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,8 +1,8 @@
 {{ define "main" }}
 <main class="page-main pa4" role="main">
   <section class="page-content mw9 center">
-    <div class="flex-l items-center">
-      <div class="mh5-l w-50-l">
+    <div class="flex-l items-start home-columns">
+      <div class="w-50-l">
         <!-- {{ with .Params.title }}<h1 class="f2 f1-m fw5-ns mv4 lh-solid tracked-tight">{{ . }}</h1>{{ end }} -->
         <img src="/files/Firewise_Logo.png" class="w-80"/>
         {{ with .Params.subtitle }}<h2 class="f7 fw7 measure mv0 ttu tracked">{{ . }}</h2>{{ end }}
@@ -10,6 +10,7 @@
         {{ if .Params.show_action_link }}<a class="action {{ .Params.action_type }}" href="{{ .Params.action_link }}">{{ .Params.action_label | safeHTML }}</a>{{ end }}
 
         {{ partial "events" . }}
+        {{ partial "2026-events" . }}
         {{ partial "certificates" . }}
         {{ partial "documents" . }}
         {{ partial "how-can-you-help" . }}

--- a/layouts/partials/2026-events.html
+++ b/layouts/partials/2026-events.html
@@ -1,0 +1,59 @@
+<div class="community-events mt3">
+  <h2>Prosser Lakeview Estates and Woods Firewise Community Events in 2026</h2>
+
+  <p>
+    Join your neighbors for two community events focused on wildfire
+    preparedness, home hardening, and keeping Prosser Lakeview Estates and Woods safer
+    and more resilient.
+  </p>
+
+  <hr/>
+
+  <h3>1. Firewise Education Day</h3>
+  <p>
+    <b>May 30, 2026</b><br/>
+    <b>10:30 AM – 12:30 PM</b><br/>
+    <b><a href="https://www.google.com/maps/search/?api=1&query=11526+Ida+Way+Truckee+CA+96161" target="_blank" rel="noopener">11526 Ida Way</a>, Prosser Lakeview Estates and Woods</b>
+  </p>
+  <p>
+    A practical community session covering wildfire preparedness, insurance
+    considerations, defensible space, and the upgrades that matter most for
+    mountain homes.
+  </p>
+
+  <hr/>
+
+  <h3>2. <a href="https://www.sierrasun.com/news/obituaries/obituary-mike-wolf/" target="_blank" rel="noopener">Mike Wolf</a> Community Cleanup Days</h3>
+  <p>
+    <b>June 27–28, 2026</b><br/>
+    Community dumpsters available all day at designated neighborhood locations.
+  </p>
+  <p>
+    <b>Dumpster Locations:</b>
+    <ul>
+      <li><a href="https://www.google.com/maps/search/?api=1&query=12095+Rainbow+Truckee+CA+96161" target="_blank" rel="noopener">12095 Rainbow</a></li>
+      <li><a href="https://www.google.com/maps/search/?api=1&query=12416+Lilac+Court+Truckee+CA+96161" target="_blank" rel="noopener">12416 Lilac Court</a></li>
+      <li><a href="https://www.google.com/maps/search/?api=1&query=11256+Ida+Way+Truckee+CA+96161" target="_blank" rel="noopener">11256 Ida Way</a></li>
+    </ul>
+  </p>
+  <p>
+    <b>Green Waste Only.</b> Accepted materials include:
+    <ul>
+      <li>Branches</li>
+      <li>Limbs</li>
+      <li>Pine needles</li>
+      <li>Cones</li>
+      <li>Brush</li>
+    </ul>
+  </p>
+  <p>
+    Please no trash, dirt, rocks, bagged material, or construction debris.
+  </p>
+
+  <hr/>
+
+  <p>
+    Together, these community efforts help reduce wildfire risk and strengthen
+    the safety of our neighborhood.
+  </p>
+</div>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,12 +1,12 @@
 <header class="site-header pa4 bb b--transparent" role="banner">
   <nav class="site-nav db dt-l w-100" role="nav">
     <a class="site-brand db dtc-l v-mid link no-underline w-100 w-60-l tc tl-l" href="{{ .Site.BaseURL }}" title="Home">
-      <img src="{{ .Site.Params.logo }}" class="dib h3 v-mid w-auto pr3" style="float: left;" alt="{{ .Site.Title }}">
-      <div>
-        <span class="v-mid f1 fw8 fire-red">{{ .Site.Title }}</span>
-        <div class="subtitle">
-          {{ .Site.Params.subtitle }}
-        </div>
+      <span class="site-wordmark">
+        <img src="{{ .Site.Params.logo }}" class="site-logo h3 v-mid w-auto" alt="{{ .Site.Title }}">
+        <span class="site-title v-mid f2 f1-ns fw8 fire-red">{{ .Site.Title }}</span>
+      </span>
+      <div class="subtitle">
+        {{ .Site.Params.subtitle }}
       </div>
     </a>
     <div class="site-links db dtc-l v-mid w-100 w-47-l tc tr-l mt3 mt0-l">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -11,14 +11,19 @@
     </a>
     <div class="site-links db dtc-l v-mid w-100 w-47-l tc tr-l mt3 mt0-l">
       {{ range $.Site.Data.navigation.header }}
+      {{ if not .icon }}
       <a class="link f6 f5-l dib pv1 ph2" href="{{ .url }}" title="{{ .title }}">
-        {{ with .icon }}
-        <img class="navicon" src="{{ . }}"/>
-        {{ end }}
-        {{ with .name }}
-        {{ .}}
-        {{ end }}</a>
+        {{ with .name }}{{ . }}{{ end }}</a>
       {{ end }}
+      {{ end }}
+      <span class="site-social">
+        {{ range $.Site.Data.navigation.header }}
+        {{ if .icon }}
+        <a class="link f6 f5-l dib pv1 ph2" href="{{ .url }}" title="{{ .title }}">
+          <img class="navicon" src="{{ .icon }}"/></a>
+        {{ end }}
+        {{ end }}
+      </span>
       {{ if .Site.Params.socialInHeader }}
       <div class="dib v-mid">
         {{ partial "shared/social-links.html" . }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,2 @@
-[context.production.environment]
+[build.environment]
   HUGO_VERSION = "0.147.3"


### PR DESCRIPTION
## Summary
- Adds a 2026 Firewise community events section to the homepage (Education Day on May 30; Mike Wolf Community Cleanup Days on June 27-28) with Google Maps links on every address.
- Reworks the mobile header so the logo and 'Prosser Firewise' read as a single inline wordmark that can't split across lines, and fixes the longstanding header padding asymmetry caused by `<nav>` not being in Tachyons' `box-sizing: border-box` reset.
- On wide screens, switches column separation to flex `gap` (not margins) and aligns the right column (defensible-space-log) to the top instead of vertically centered.

## Test plan
- [x] Verify the 2026 events block renders with the light sage background and Google Maps links open in a new tab.
- [x] On a phone (~375-414px) and a narrow tablet (~600px), confirm header padding is symmetric on both sides and the wordmark stays intact.
- [x] Below 460px, confirm the menu wraps to two rows: About/Homeowners/Committee on top, Resources/FB/GH on bottom, both left-aligned.
- [x] On desktop, confirm the green defensible-space-log banner now sits at the top of the right column.